### PR TITLE
Add `1.5.x` in the issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -38,6 +38,7 @@ body:
       description: "What version of Appwrite are you running?"
       options:
         - Appwrite Cloud
+        - Version 1.5.x
         - Version 1.4.x
         - Version 1.3.x
         - Version 1.2.x


### PR DESCRIPTION
## What does this PR do?

Adds the `1.5.x` version in the issue template for selecting an appropriate appwrite version.

## Test Plan

None.

## Related PRs and Issues

N/A on GitHub.
Discord Source - https://discord.com/channels/564160730845151244/636852860709240842/1217808126171021352.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.