### PR TITLE
chore: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,7 +1,6 @@
 name: "🐛 Bug Report"
 description: "Submit a bug report to help us improve"
-title: "🐛 Bug Report: "
-labels: [bug]
+type: "bug"
 body:
   - type: markdown
     attributes:
@@ -15,6 +14,11 @@ body:
       label: "👟 Reproduction steps"
       description: "How do you trigger this bug? Please walk us through it step by step."
       placeholder: "When I ..."
+      value: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
   - type: textarea
     id: expected-behavior
     validations:
@@ -38,6 +42,8 @@ body:
       description: "What version of Appwrite are you running?"
       options:
         - Appwrite Cloud
+        - Version 1.8.x
+        - Version 1.7.x
         - Version 1.6.x
         - Version 1.5.x
         - Version 1.4.x

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -1,6 +1,5 @@
 name: "📚 Documentation"
 description: "Report an issue related to documentation"
-title: "📚 Documentation: "
 labels: [documentation]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yaml
@@ -1,7 +1,6 @@
 name: 🚀 Enhancement
 description: "Submit a proposal for a new feature or change"
-title: "🚀 Enhancement: "
-labels: [enhancement]
+type: "enhancement"
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- remove enhancementand bug title prefix and labels in favor of issue types
- add reproduction steps example to bug report
- add Appwrite version 1.8.x and 1.7.x to bug report

## Test Plan

None

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Refreshed GitHub issue templates to use a “type” field (Bug, Enhancement) and removed pre-filled titles/labels where applicable.
  - Bug Report: added guided steps-to-reproduce placeholder and expanded version selector with 1.8.x and 1.7.x.
  - Documentation Issue: removed pre-filled title to streamline submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->